### PR TITLE
Draft: try to reduce circuits by avoiding negative number vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,33 +174,14 @@ Currently the project is targeting [powersOfTau28_hez_final_20.ptau](https://git
 |---------|-------------|
 | absoluteValueSubtraction(252) | 257 |
 | acceptableMarginOfError(60) | 126 |
-| calculateForce() | 842 |
+| calculateForce() | 1,340 |
 | detectCollision(3) | 1,548 |
-| forceAccumulator(3) | 4,518 |
+| forceAccumulator(3) | 6,012 |
 | getDistance(252) | 1,026 |
 | limiter(252) | 254 |
 | lowerLimiter(252) | 254 |
-| nft(2, 1) | 2,170 |
-| nft(2, 10) | 21,700 |
-| nft(2, 100) | 217,000 |
-| nft(3, 1) | 4,518 |
-| nft(3, 10) | 45,180 |
-| nft(3, 100) | 451,800 |
-| nft(4, 1) | 7708 |
-| nft(4, 10) | 77,080 |
-| nft(4, 100) | 770,800 |
-| nft(5, 1) | 11,740 |
-| nft(5, 10) | 117,400 |
-| nft(5, 100) | 1,174,000 |
-| stepState(2, 1) | 3,293 |
-| stepState(2, 10) | 32,930 |
-| stepState(2, 100) | 329,300 |
-| stepState(3, 1) | 7,653 |
+| nft(3, 10) | 60,120 |
 | stepState(3, 10) | 76,530 |
-| stepState(3, 100) | 765,300 |
-| stepState(4, 1) | 9,863 |
-| stepState(4, 10) | 98,630 |
-| stepState(4, 100) | 986,300 |
 
 # built using circom-starter
 

--- a/README.md
+++ b/README.md
@@ -195,9 +195,9 @@ Currently the project is targeting [powersOfTau28_hez_final_20.ptau](https://git
 | stepState(2, 1) | 3,293 |
 | stepState(2, 10) | 32,930 |
 | stepState(2, 100) | 329,300 |
-| stepState(3, 1) | 6,157 |
-| stepState(3, 10) | 61,570 |
-| stepState(3, 100) | 615,700 |
+| stepState(3, 1) | 7,653 |
+| stepState(3, 10) | 76,530 |
+| stepState(3, 100) | 765,300 |
 | stepState(4, 1) | 9,863 |
 | stepState(4, 10) | 98,630 |
 | stepState(4, 100) | 986,300 |

--- a/circuits/approxMath.circom
+++ b/circuits/approxMath.circom
@@ -103,23 +103,23 @@ template AbsoluteValueSubtraction (n) {
     out <== greaterValue - lesserValue;
 }
 
-// TODO: Confirm this doesn't work because most_positive_number is too large for LessThan circuit
-template AbsoluteValue() {
-  signal input in;
-  signal output out;
-  signal most_positive_number <== 10944121435919637611123202872628637544274182200208017171849102093287904247808;
-  // p = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
-  // p_minus_one = 21888242871839275222246405745257275088548364400416034343698204186575808495616;
+// NOTE: This isn't an efficient system because LessThan has max 252 bits, which could be overridden but still not ideal
+// template AbsoluteValue() {
+//   signal input in;
+//   signal output out;
+//   signal most_positive_number <== 10944121435919637611123202872628637544274182200208017171849102093287904247808;
+//   // p = 21888242871839275222246405745257275088548364400416034343698204186575808495617;
+//   // p_minus_one = 21888242871839275222246405745257275088548364400416034343698204186575808495616;
 
-  component lessThan = LessThan(252); // TODO: confirm this is necessary for most_positive_number
-  lessThan.in[0] <== in;
-  lessThan.in[1] <== most_positive_number;
+//   component lessThan = LessThan(252); // TODO: confirm this is necessary for most_positive_number
+//   lessThan.in[0] <== in;
+//   lessThan.in[1] <== most_positive_number;
 
-  component myMux = Mux1();
-  myMux.c[0] <== in * -1;
-  myMux.c[1] <== in; // TODO: confirm whether cheaper to do p - in using p as signal
-  myMux.s <== lessThan.out;
+//   component myMux = Mux1();
+//   myMux.c[0] <== in * -1;
+//   myMux.c[1] <== in; // TODO: confirm whether cheaper to do p - in using p as signal
+//   myMux.s <== lessThan.out;
 
-  out <== myMux.out;
-}
+//   out <== myMux.out;
+// }
 

--- a/circuits/calculateForce.circom
+++ b/circuits/calculateForce.circom
@@ -28,42 +28,59 @@ template CalculateForce() {
     return createVector(forceX, forceY);
 */
 
-  var scalingFactor = 10**8;
-  var GScaled =  100 * scalingFactor; // TODO: these could be constrained, do they need to be?
+
+  // NOTE: scalingFactorFactor appears in calculateMissile, forceAccumulator as well
+  var scalingFactorFactor = 8; // maxBits: 4
+  var scalingFactor = 10**scalingFactorFactor; // maxBits: 27
+  
+  var Gravity = 100; // maxBits: 7
+  var minDistance = 200; // maxBits: 8
+
+
+  // NOTE: windowWidth appears in calculateMissile, forceAccumulator as well and needs to match
+  var windowWidth = 1000; // maxBits: 10
+  var windowWidthScaled = windowWidth * scalingFactor; // maxBits: 37
+
+
+   // TODO: these could be constrained, do they need to be?
+  var GScaled =  Gravity * scalingFactor; // maxBits: 34
   // log("GScaled", GScaled);
-
-    var divisionBits = 120; // TODO: test the limits of this. 
-
 
   signal input in_bodies[2][5];
   signal output out_forces[2];
 
-  signal minDistanceScaled <== 200 * 200 * scalingFactor * scalingFactor; // NOTE: this is 200**2 so we have to square the scaling factor too
+ // NOTE: this is 200**2 so we have to square the scaling factor too
+  signal minDistanceScaled <== (minDistance ** 2) * (scalingFactor ** 2); // maxBits: 69
+  // NOTE: minDistanceScaled is maximum of 
   // log("minDistanceScaled", minDistanceScaled);
-  var body1_position_x = in_bodies[0][0];
+  var body1_position_x = in_bodies[0][0]; // maxBits: 37 = windowWidthScaled
   // log("body1_position_x", body1_position_x);
-  var body1_position_y = in_bodies[0][1];
+  var body1_position_y = in_bodies[0][1]; // maxBits: 37 = windowWidthScaled
   // log("body1_position_y", body1_position_y);
-  var body1_radius = in_bodies[0][4];
 
-  var body2_position_x = in_bodies[1][0];
+  // NOTE: maximum radius currently 13
+  var body1_radius = in_bodies[0][4]; // maxBits: 31 = numBits(13 * scalingFactor)
+
+  var body2_position_x = in_bodies[1][0]; // maxBits: 37 = windowWidthScaled
   // log("body2_position_x", body2_position_x);
-  var body2_position_y = in_bodies[1][1];
+  var body2_position_y = in_bodies[1][1]; // maxBits: 37 = windowWidthScaled
   // log("body2_position_y", body2_position_y);
-  var body2_radius = in_bodies[1][4];
+  
+  // NOTE: maximum radius currently 13
+  var body2_radius = in_bodies[1][4]; // maxBits: 31 = numBits(13 * scalingFactor)
 
-  signal dx <== body2_position_x - body1_position_x;
+  signal dx <== body2_position_x - body1_position_x; // maxBits: 254 because it can be negative
 
-  component absoluteValueSubtraction = AbsoluteValueSubtraction(60); // TODO: test limit
+  component absoluteValueSubtraction = AbsoluteValueSubtraction(37);
   absoluteValueSubtraction.in[0] <== body1_position_x;
   absoluteValueSubtraction.in[1] <== body2_position_x;
-  signal dxAbs <== absoluteValueSubtraction.out;
+  signal dxAbs <== absoluteValueSubtraction.out; // maxBits: 37
 
-  signal dy <== body2_position_y - body1_position_y;
-  component absoluteValueSubtraction2 = AbsoluteValueSubtraction(60); // TODO: test limit
+  signal dy <== body2_position_y - body1_position_y; // maxBits: 254 because it can be negative
+  component absoluteValueSubtraction2 = AbsoluteValueSubtraction(37);
   absoluteValueSubtraction2.in[0] <== body1_position_y;
   absoluteValueSubtraction2.in[1] <== body2_position_y;
-  signal dyAbs <== absoluteValueSubtraction2.out;
+  signal dyAbs <== absoluteValueSubtraction2.out; // maxBits: 37
 
   // log("dx", dx);
   // log("dy", dy);
@@ -72,118 +89,127 @@ template CalculateForce() {
   // log("dxAbs", dxAbs);
   // log("dyAbs", dyAbs);
 
-  signal dxs <== dxAbs * dxAbs;
+  signal dxs <== dxAbs * dxAbs; // maxBits: 74 = 37 * 2
   // log("dxs", dxs);
-  signal dys <== dyAbs * dyAbs;
+  signal dys <== dyAbs * dyAbs; // maxBits: 74 = 37 * 2
   // log("dys", dys);
-  signal unboundDistanceSquared <== dxs + dys;
+  signal unboundDistanceSquared <== dxs + dys; // maxBits: 75 = 74 + 1
   // log("unboundDistanceSquared", unboundDistanceSquared);
 
-  component lessThan = LessThan(75); // NOTE: max distance should be corner to corner of max grid size
+  component lessThan = LessThan(75); // NOTE: also because unboundDistanceSquared is 75
+  // NOTE: max distance should be corner to corner of max grid size
   // max grid is 1000_00000000 which means 1000_00000000 * sqrt(2) = 1414_21356237
   // 1414_21356237**2 is 19,999,999,999,912,458,800,169
   // 19,999,999,999,912,460,800,000 in bits is 76
   // max number using 75 bits is 2**75 - 1 = 75,557,863,725,914,323,419,135
-  lessThan.in[0] <== unboundDistanceSquared;
-  lessThan.in[1] <== minDistanceScaled;
+  lessThan.in[0] <== unboundDistanceSquared; // maxBits: 75
+  lessThan.in[1] <== minDistanceScaled; // maxBits: 69
 
   // distanceSquared <== is_below_minimum ? minDistanceScaled : unboundDistanceSquared;
   component myMux = Mux1();
-  myMux.c[0] <== unboundDistanceSquared;
-  myMux.c[1] <== minDistanceScaled;
+  myMux.c[0] <== unboundDistanceSquared; // maxBits: 75
+  myMux.c[1] <== minDistanceScaled; // maxBits: 69
   myMux.s <== lessThan.out;
-  signal distanceSquared <== myMux.out;
+  signal distanceSquared <== myMux.out; // maxBits: 75
 
   // NOTE: confirm this is correct
-  signal distance <-- approxSqrt(distanceSquared);
+  // NOTE: squre root should require half as many bits as the input
+  // TODO: confirm that 2 bit more is enough for the margin of error of distance * 2
+  signal distance <-- approxSqrt(distanceSquared); // maxBits: 39 = 75 / 2 + 2
   // log("distance", distance);
   // log("distanceSquared", distanceSquared);
   // bits should be maximum of the vectorLimiter which would be (10 * 10 ** 8) * (10 * 10 ** 8) which is under 60 bits
-  component acceptableMarginOfError = AcceptableMarginOfError(60);  // TODO: test the limits of this. 
-  acceptableMarginOfError.expected <== distance ** 2;
-  acceptableMarginOfError.actual <== distanceSquared;
+  component acceptableMarginOfError = AcceptableMarginOfError(78);  // TODO: test the limits of this. 
+  acceptableMarginOfError.expected <== distance ** 2; // maxBits: 78 = 39 * 2
+  acceptableMarginOfError.actual <== distanceSquared; // maxBits: 75
   // margin of error should be midpoint between squares
   acceptableMarginOfError.marginOfError <== distance * 2; // TODO: confrim if (distance * 2) +1 is needed
   acceptableMarginOfError.out === 1;
 
 
-  signal bodies_sum_tmp <== (body1_radius + body2_radius) * 4; // NOTE: this could be tweaked as a variable for "liveliness" of bodies
+ // NOTE: this could be tweaked as a variable for "liveliness" of bodies
+  signal bodies_sum_tmp <== (body1_radius + body2_radius) * 4; // maxBits: 34 = 31 + 1 + 2
 
   // bodies_sum is 0 if either body1_radius or body2_radius is 0
   component isZero = IsZero();
   isZero.in <== body1_radius;
 
   component myMux2 = Mux1();
-  myMux2.c[0] <== bodies_sum_tmp;
-  myMux2.c[1] <== 0;
+  myMux2.c[0] <== bodies_sum_tmp; // maxBits: 34
+  myMux2.c[1] <== 0; // maxBits: 0
   myMux2.s <== isZero.out;
 
   component isZero2 = IsZero();
-  isZero2.in <== body2_radius;
+  isZero2.in <== body2_radius; // maxBits: 31
 
   component myMux3 = Mux1();
-  myMux3.c[0] <== myMux2.out;
-  myMux3.c[1] <== 0;
+  myMux3.c[0] <== myMux2.out; // maxBits: 34
+  myMux3.c[1] <== 0; // maxBits: 0
   myMux3.s <== isZero2.out;
-  signal bodies_sum <== myMux3.out;
+  signal bodies_sum <== myMux3.out; // maxBits: 34
 
   // log("bodies_sum", bodies_sum);
 
-  signal distanceSquared_with_avg_denom <== distanceSquared * 2; // NOTE: this is a result of moving division to end of calculation to preserve precision
+ // NOTE: this is a result of moving division to end of calculation to preserve precision
+  signal distanceSquared_with_avg_denom <== distanceSquared * 2; // maxBits: 76 = 75 + 1
   // log("distanceSquared_with_avg_denom", distanceSquared_with_avg_denom);
-  signal forceMag_numerator <== GScaled * bodies_sum * scalingFactor; // NOTE: distance should be divided by scaling factor, but we can multiply GScaled by scaling factor instead to prevent division rounding errors
+
+   // NOTE: distance should be divided by scaling factor, but we can multiply GScaled by scaling factor instead to prevent division rounding errors
+  signal forceMag_numerator <== GScaled * bodies_sum * scalingFactor; // maxBits: 95 = 34 + 34 + 27
   // log("forceMag_numerator", forceMag_numerator);
 
-  signal forceDenom <== distanceSquared_with_avg_denom * distance;
+  signal forceDenom <== distanceSquared_with_avg_denom * distance; // maxBits: 115 = 76 + 39
   // log("forceDenom", forceDenom);
 
-  signal forceXnum <== dxAbs * forceMag_numerator;
+  signal forceXnum <== dxAbs * forceMag_numerator; // maxBits: 132 = 37 + 95
   // log("forceXnum", forceXnum);
-  signal forceXunsigned <-- approxDiv(forceXnum, forceDenom);
+  signal forceXunsigned <-- approxDiv(forceXnum, forceDenom); // maxBits: 132 = forceXnum
   // log("forceXunsigned", forceXunsigned);
 // NOTE: the following constraints the approxDiv to ensure it's within the acceptable error of margin
-  signal approxNumerator1 <== forceXunsigned * forceDenom;
-  component acceptableErrorOfMarginDiv1 = AcceptableMarginOfError(divisionBits);  // TODO: test the limits of this. 
-  acceptableErrorOfMarginDiv1.expected <== forceXnum;
-  acceptableErrorOfMarginDiv1.actual <== approxNumerator1;
+  signal approxNumerator1 <== forceXunsigned * forceDenom; // maxBits: 247 = 132 + 115
+  component acceptableErrorOfMarginDiv1 = AcceptableMarginOfError(247);
+  acceptableErrorOfMarginDiv1.expected <== forceXnum; // maxBits: 132
+  acceptableErrorOfMarginDiv1.actual <== approxNumerator1; // maxBits: 247
   acceptableErrorOfMarginDiv1.marginOfError <== forceDenom; // TODO: actually could be further reduced to (realDenom / 2) + 1 but then we're using division again
   acceptableErrorOfMarginDiv1.out === 1;
 
   // if dxAbs + dx is 0, then forceX should be negative
   component isZero3 = IsZero();
-  isZero3.in <== dxAbs + dx;
+  // NOTE: isZero handles overflow bit values correctly
+  isZero3.in <== dxAbs + dx; // maxBits: 255 = max(37, 254) + 1
   // log("isZero3", dxAbs + dx, isZero3.out);
   component myMux4 = Mux1();
-  myMux4.c[0] <== forceXunsigned;
-  myMux4.c[1] <== forceXunsigned * -1;
+  myMux4.c[0] <== forceXunsigned; // maxBits: 132
+  myMux4.c[1] <== forceXunsigned * -1; // maxBits: 254
   myMux4.s <== isZero3.out;
-  signal forceX <== myMux4.out;
+  signal forceX <== myMux4.out; // maxBits: 254
   // log("forceX", forceX);
 
-  signal forceYnum <== dyAbs * forceMag_numerator;
+  signal forceYnum <== dyAbs * forceMag_numerator; // maxBits: 132 = 37 + 95
   // log("forceYnum", forceYnum);
-  signal forceYunsigned <-- approxDiv(forceYnum, forceDenom);
+  signal forceYunsigned <-- approxDiv(forceYnum, forceDenom); // maxBits: 132 = forceYnum
   // log("forceYunsigned", forceYunsigned);
   // NOTE: the following constraints the approxDiv to ensure it's within the acceptable error of margin
-  signal approxNumerator2 <== forceYunsigned * forceDenom;
-  component acceptableErrorOfMarginDiv2 = AcceptableMarginOfError(divisionBits);  // TODO: test the limits of this. 
-  acceptableErrorOfMarginDiv2.expected <== forceYnum;
-  acceptableErrorOfMarginDiv2.actual <== approxNumerator2;
+  signal approxNumerator2 <== forceYunsigned * forceDenom; // maxBits: 247 = 132 + 115
+  component acceptableErrorOfMarginDiv2 = AcceptableMarginOfError(247);
+  acceptableErrorOfMarginDiv2.expected <== forceYnum; // maxBits: 132
+  acceptableErrorOfMarginDiv2.actual <== approxNumerator2; // maxBits: 247
   acceptableErrorOfMarginDiv2.marginOfError <== forceDenom; // TODO: actually could be further reduced to (realDenom / 2) + 1 but then we're using division again
   acceptableErrorOfMarginDiv2.out === 1;
 
   // if dyAbs + dy is 0, then forceY should be negative
   component isZero4 = IsZero();
-  isZero4.in <== dyAbs + dy;
+    // NOTE: isZero handles overflow bit values correctly
+  isZero4.in <== dyAbs + dy; // maxBits: 255 = max(37, 254) + 1
   component myMux5 = Mux1();
-  myMux5.c[0] <== forceYunsigned;
-  myMux5.c[1] <== forceYunsigned * -1;
+  myMux5.c[0] <== forceYunsigned; // maxBits: 132
+  myMux5.c[1] <== forceYunsigned * -1; // maxBits: 254
   myMux5.s <== isZero4.out;
-  signal forceY <== myMux5.out;
+  signal forceY <== myMux5.out; // maxBits: 254
   // log("forceY", forceY);
 
-  out_forces[0] <== forceX;
-  out_forces[1] <== forceY;
+  out_forces[0] <== forceX; // maxBits: 254
+  out_forces[1] <== forceY; // maxBits: 254
 }
 
 

--- a/circuits/calculateMissile.circom
+++ b/circuits/calculateMissile.circom
@@ -14,9 +14,9 @@ This function calculates the movement of one missile using the following inputs:
 The calculation is a simple addition of the x vector with the x position and the 
 y vector with the y position.
 
-The missile is shot from position (0, windowWidth) and x vector is always positive
+The missile is shot from position (0, windowWidthScaled) and x vector is always positive
 and y vector is always negative. If the missile reaches the edge of the screen it
-will either be in the X direction at windowWidth or in the Y direction at 0.
+will either be in the X direction at windowWidthScaled or in the Y direction at 0.
 
 If the missile reaches the edge of the screen in either direction it will be removed 
 and the radius is reduced to 0.
@@ -25,25 +25,35 @@ and the radius is reduced to 0.
 
 template CalculateMissile() {
   signal input in_missile[5];
-
   signal output out_missile[5];
 
+
+  // NOTE: scalingFactorFactor appears in calculateForce, forceAccumulator as well
+  var scalingFactorFactor = 8; // maxBits: 4
+  var scalingFactor = 10**scalingFactorFactor; // maxBits: 27
+
+
+  // NOTE: windowWidthScaled appears in forceAccumulator, calculateForce as well and needs to match
+  var windowWidth = 1000; // maxBits: 10
+  var windowWidthScaled = windowWidth * scalingFactor; // maxBits: 37
+
   // TODO: confirm the max vector of missiles (may change frequently)
-  var maxVector = 1000000000; // using 10^8 decimals
-  // log("maxVector", maxVector);
-  // NOTE: windowWidth appears in forceAccumulator as well and needs to match
-  var windowWidth = 100000000000; // using 10^8 decimals
+  var maxVector = 10; // maxBits: 4
+  var maxVectorScaled = maxVector * scalingFactor; // maxBits: 27
+  // log("maxVectorScaled", maxVectorScaled);
 
   signal new_pos[2];
-  new_pos[0] <== in_missile[0] + in_missile[2]; // position_x + vector_x
-  new_pos[1] <== in_missile[1] + in_missile[3]; // position_y + vector_y
+   // position_x + vector_x
+  new_pos[0] <== in_missile[0] + in_missile[2]; // maxBits: 38 = 37 + 1 = windowWidthScaled + 1
+   // position_y + vector_y
+  new_pos[1] <== in_missile[1] + in_missile[3]; // maxBits: 38 = 37 + 1 = windowWidthScaled + 1
 
-  // position X is only going to increase from 0 to windowWidth
-  // it needs to be kept less than windowWidth
+  // position X is only going to increase from 0 to windowWidthScaled
+  // it needs to be kept less than windowWidthScaled
   // can return 0 if it exceeds and use this information to remove the missile
   component positionLimiterX = Limiter(37); // TODO: confirm type matches bit limit
-  positionLimiterX.in <== new_pos[0] + maxVector;
-  positionLimiterX.limit <== windowWidth + maxVector;
+  positionLimiterX.in <== new_pos[0] + maxVectorScaled; // maxBits: 39 = max(38, 27) + 1
+  positionLimiterX.limit <== windowWidthScaled + maxVectorScaled; // maxBits: 38 = max(37, 27) + 1
   positionLimiterX.rather <== 0;
 
   // This is for the radius of the missile
@@ -57,16 +67,16 @@ template CalculateMissile() {
   muxX.c[1] <== 0;
   muxX.s <== isZeroX.out;
 
-  // Since the plane goes from 0 to windowWidth on the y axis from top to bottom
-  // the missile will approach 0 after starting at windowWidth
-  // check whether it goes below 0 by using the maxVector as a buffer
-  // return 0 if it is below maxVector to remove the missile
+  // Since the plane goes from 0 to windowWidthScaled on the y axis from top to bottom
+  // the missile will approach 0 after starting at windowWidthScaled
+  // check whether it goes below 0 by using the maxVectorScaled as a buffer
+  // return 0 if it is below maxVectorScaled to remove the missile
   // TODO: this assumes a missile removal at less than or equal to 0
   // make sure the JS also is <= 0 and not just < 0 for the missile removal
   // also check the general overboard logic. Would be an edge case but possible.
-  component positionLowerLimiterY = LowerLimiter(37); // TODO: confirm type matches bit limit
-  positionLowerLimiterY.in <== new_pos[1] + maxVector;
-  positionLowerLimiterY.limit <== maxVector;
+  component positionLowerLimiterY = LowerLimiter(39); // TODO: confirm type matches bit limit
+  positionLowerLimiterY.in <== new_pos[1] + maxVectorScaled; // maxBits: 39 = max(38, 27) + 1
+  positionLowerLimiterY.limit <== maxVectorScaled; // maxBits: 27
   positionLowerLimiterY.rather <== 0;
 
   component isZeroY = IsZero();
@@ -76,8 +86,8 @@ template CalculateMissile() {
   muxY.c[1] <== 0;
   muxY.s <== isZeroY.out;
 
-  out_missile[0] <== new_pos[0]; // position_x + vector_x
-  out_missile[1] <== new_pos[1]; // position_y + vector_y
+  out_missile[0] <== new_pos[0]; // maxBits: 38
+  out_missile[1] <== new_pos[1]; // maxBits: 38
   out_missile[2] <== in_missile[2];
   out_missile[3] <== in_missile[3];
   out_missile[4] <== muxY.out; // will have the update radius

--- a/circuits/getDistance.circom
+++ b/circuits/getDistance.circom
@@ -10,13 +10,13 @@ template GetDistance(n) {
   signal output distance;
 
   // signal dx <== x2 - x1;
-  component absoluteValueSubtraction = AbsoluteValueSubtraction(n); // TODO: test limit
+  component absoluteValueSubtraction = AbsoluteValueSubtraction(n);
   absoluteValueSubtraction.in[0] <== x1;
   absoluteValueSubtraction.in[1] <== x2;
   signal dxAbs <== absoluteValueSubtraction.out;
 
   // signal dy <== y2 - y1;
-  component absoluteValueSubtraction2 = AbsoluteValueSubtraction(n); // TODO: test limit
+  component absoluteValueSubtraction2 = AbsoluteValueSubtraction(n);
   absoluteValueSubtraction2.in[0] <== y1;
   absoluteValueSubtraction2.in[1] <== y2;
   signal dyAbs <== absoluteValueSubtraction2.out;
@@ -28,7 +28,7 @@ template GetDistance(n) {
   // NOTE: confirm this is correct
   distance <-- approxSqrt(distanceSquared);
   // bits should be maximum of the vectorLimiter which would be (10 * 10 ** 8) * (10 * 10 ** 8) which is under 60 bits
-  component acceptableMarginOfError = AcceptableMarginOfError(n);  // TODO: test the limits of this. 
+  component acceptableMarginOfError = AcceptableMarginOfError(n);
   acceptableMarginOfError.expected <== distanceSquared;
   acceptableMarginOfError.actual <== distance ** 2;
   // margin of error should be midpoint between squares

--- a/circuits/helpers.circom
+++ b/circuits/helpers.circom
@@ -1,0 +1,17 @@
+pragma circom 2.1.6;
+
+function getX(body) {
+    return body[0];
+}
+function getY(body) {
+  return body[1];
+}
+function getVx(body) {
+  return [body[2], body[3]];
+}
+function getVy(body) {
+  return [body[4], body[5]];
+}
+function getMass(body) {
+  return body[6];
+}


### PR DESCRIPTION
I started converting the `CalculateForce` template so that instead of returning an array of 2 values (`signal output out_forces[2]`) of the x and y vectors that include the possibility of negative numbers and therefore have a maximum bit size of `254`, it would return 2 arrays of 2 values (`signal output out_forces[2][2]`) where the first array is x and the second array is y such that the values for x or y are broken up into two numbers, the first is either 0 or 1 for whether the next value is negative or not and the second value is the unsigned version of the value.

For example:
```circom
// before
component calculateForce = CalculateForce();
calculateForce.in_bodies[0] <== bodies[0];
calculateForce.in_bodies[1] <== bodies[1];
signal force_x <== calculateForce.out[0]; // maxBits: 254
signal force_y <== calculateForce.out[1]; // maxBits: 254

// after
component calculateForce = CalculateForce();
calculateForce.in_bodies[0] <== bodies[0];
calculateForce.in_bodies[1] <== bodies[1];
signal is_force_x_negative <== calculateForce.out[0][0]; // maxBits: 1
signal unsigned_force_x <== calculateForce.out[0][1]; // maxBits: 132
signal is_force_y_negative <== calculateForce.out[1][0]; // maxBits: 1
signal unsigned_force_y <== calculateForce.out[1][1]; // maxBits: 132
```

After converting `CalculateForce` template I started updating `ForceAccumulator` template. It was here that I had to reconsider whether I was using `accumulated_body_forces` correctly or not. I had been treating it as a `var` which implied it was a [Known](https://docs.circom.io/circom-language/circom-insight/unknowns/) value. However, due to the fact that it is an accumulation of [Unknown](https://docs.circom.io/circom-language/circom-insight/unknowns/) values, I think it needs to be changed from `var` to `signal`.

I changed it to a `signal` and turned `accumulated_body_forces` into an array of length `totalIterations + 1` due to the fact that it needed to accumulate values by combining the previous value with the current value and would require +1 to account for the first iteration that has no previous value.

This made me question whether I was handling signals correctly. Is the following circuit properly constrained?
(link to [zkrepl](https://zkrepl.dev/?gist=b5f3d99ec1bfb32235eac67b81277c2b))

```circom
template add() {
    signal input a;
    signal input b;
    signal output out <== a + b;
}

template Example () {
    signal input a;
    signal input b;
    signal output c;
    
    var accum = 0;
    component adder[10];
    for (var i = 0; i < 10; i++) {
        adder[i] = add();
        adder[i].a <== a;
        adder[i].b <== b;
        accum = accum + adder[i].out;
    }
    c <== accum;
}
```

My understanding from [these](https://docs.circom.io/circom-language/circom-insight/unknowns/) docs on `Unknown`/`Known` values makes me think that `accum` is a combination of a known value (`0`) and an unknown value (`adder[i].out`) which should make it an Unknown value and therefore needs to be constrained. `c` is being constrained to equal `accum`, but `accum` is not itself constrained so this is unsafe?
