### PR TITLE
use var in stepState and ignore velocity in detectCollision

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Currently the project is targeting [powersOfTau28_hez_final_20.ptau](https://git
 | absoluteValueSubtraction(252) | 259 |
 | acceptableMarginOfError(60) | 128 |
 | calculateForce() | 717 |
-| detectCollision(3) | 526 |
+| detectCollision(3) | 510 |
 | forceAccumulator(3) | 2821 |
 | getDistance(20) | 142 |
 | limiter(252) | 257 |

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Currently the project is targeting [powersOfTau28_hez_final_20.ptau](https://git
 | limiter(252) | 257 |
 | lowerLimiter(252) | 257 |
 | nft(3, 10) | 28039 |
-| stepState(3, 10) | 33891 |
+| stepState(3, 10) | 33531 |
 
 # built using circom-starter
 

--- a/circuits/calculateMissile.circom
+++ b/circuits/calculateMissile.circom
@@ -29,31 +29,31 @@ template CalculateMissile() {
 
 
   // NOTE: scalingFactorFactor appears in calculateForce, forceAccumulator as well
-  var scalingFactorFactor = 8; // maxBits: 4
-  var scalingFactor = 10**scalingFactorFactor; // maxBits: 27
+  var scalingFactorFactor = 3; // maxBits: 2
+  var scalingFactor = 10**scalingFactorFactor; // maxBits: 10 (maxNum: 1_000)
 
 
   // NOTE: windowWidthScaled appears in forceAccumulator, calculateForce as well and needs to match
   var windowWidth = 1000; // maxBits: 10
-  var windowWidthScaled = windowWidth * scalingFactor; // maxBits: 37
+  var windowWidthScaled = windowWidth * scalingFactor; // maxBits: 20 (maxNum: 1_000_000)
 
   // TODO: confirm the max vector of missiles (may change frequently)
   var maxVector = 10; // maxBits: 4
-  var maxVectorScaled = maxVector * scalingFactor; // maxBits: 27
+  var maxVectorScaled = maxVector * scalingFactor; // maxBits: 14 (maxNum: 10_000)
   // log("maxVectorScaled", maxVectorScaled);
 
   signal new_pos[2];
    // position_x + vector_x
-  new_pos[0] <== in_missile[0] + in_missile[2]; // maxBits: 38 = 37 + 1 = windowWidthScaled + 1
+  new_pos[0] <== in_missile[0] + in_missile[2]; // maxBits: 20 (maxNum: 1_010_000)
    // position_y + vector_y
-  new_pos[1] <== in_missile[1] + in_missile[3]; // maxBits: 38 = 37 + 1 = windowWidthScaled + 1
+  new_pos[1] <== in_missile[1] + in_missile[3]; // maxBits: 20 (maxNum: 1_010_000)
 
   // position X is only going to increase from 0 to windowWidthScaled
   // it needs to be kept less than windowWidthScaled
   // can return 0 if it exceeds and use this information to remove the missile
-  component positionLimiterX = Limiter(37); // TODO: confirm type matches bit limit
-  positionLimiterX.in <== new_pos[0] + maxVectorScaled; // maxBits: 39 = max(38, 27) + 1
-  positionLimiterX.limit <== windowWidthScaled + maxVectorScaled; // maxBits: 38 = max(37, 27) + 1
+  component positionLimiterX = Limiter(20);
+  positionLimiterX.in <== new_pos[0] + maxVectorScaled; // maxBits: 20 (maxNum: 1_020_000)
+  positionLimiterX.limit <== windowWidthScaled + maxVectorScaled; // maxBits: 20 (maxNum: 1_010_000)
   positionLimiterX.rather <== 0;
 
   // This is for the radius of the missile
@@ -74,9 +74,9 @@ template CalculateMissile() {
   // TODO: this assumes a missile removal at less than or equal to 0
   // make sure the JS also is <= 0 and not just < 0 for the missile removal
   // also check the general overboard logic. Would be an edge case but possible.
-  component positionLowerLimiterY = LowerLimiter(39); // TODO: confirm type matches bit limit
-  positionLowerLimiterY.in <== new_pos[1] + maxVectorScaled; // maxBits: 39 = max(38, 27) + 1
-  positionLowerLimiterY.limit <== maxVectorScaled; // maxBits: 27
+  component positionLowerLimiterY = LowerLimiter(20); // TODO: confirm type matches bit limit
+  positionLowerLimiterY.in <== new_pos[1] + maxVectorScaled; // maxBits: 20 (maxNum: 1_020_000)
+  positionLowerLimiterY.limit <== maxVectorScaled; // maxBits: 14 (maxNum: 10_000)
   positionLowerLimiterY.rather <== 0;
 
   component isZeroY = IsZero();
@@ -86,9 +86,9 @@ template CalculateMissile() {
   muxY.c[1] <== 0;
   muxY.s <== isZeroY.out;
 
-  out_missile[0] <== new_pos[0]; // maxBits: 38
-  out_missile[1] <== new_pos[1]; // maxBits: 38
-  out_missile[2] <== in_missile[2];
-  out_missile[3] <== in_missile[3];
-  out_missile[4] <== muxY.out; // will have the update radius
+  out_missile[0] <== new_pos[0]; // maxBits: 20 (maxNum: 1_000_000)
+  out_missile[1] <== new_pos[1]; // maxBits: 20 (maxNum: 1_000_000)
+  out_missile[2] <== in_missile[2]; // maxBits: 14 (maxNum: 10_000)
+  out_missile[3] <== in_missile[3]; // maxBits: 14 (maxNum: 10_000)
+  out_missile[4] <== muxY.out;
 }

--- a/circuits/detectCollision.circom
+++ b/circuits/detectCollision.circom
@@ -4,15 +4,15 @@ include "getDistance.circom";
 include "../node_modules/circomlib/circuits/mux1.circom";
 
 template DetectCollision(totalBodies) {
-  signal input bodies[totalBodies][5];
-  signal input missile[5];
-  signal output out_bodies[totalBodies][5];
-  signal output out_missile[5];
+  signal input bodies[totalBodies][3]; // only storing x, y and radius as 0, 1, 2
+  signal input missile[3]; // only storing x, y and radius as 0, 1, 2
+  signal output out_bodies[totalBodies][3]; // only storing x, y and radius as 0, 1, 2
+  signal output out_missile[3]; // only storing x, y and radius as 0, 1, 2
 
   signal tmp_missiles[totalBodies + 1][3]; // only storing x, y and radius as 0, 1, 2
   tmp_missiles[0][0] <== missile[0];
   tmp_missiles[0][1] <== missile[1];
-  tmp_missiles[0][2] <== missile[4];
+  tmp_missiles[0][2] <== missile[2];
 
   component getDistance[totalBodies];
   component isZero[totalBodies];
@@ -36,7 +36,7 @@ template DetectCollision(totalBodies) {
 
     // if there is no missile (isZeroOut == 1), then set distanceMin to 0. Even if they are exact same coordinates the distance will be 0 and 0 < 0 is false
     distanceMinMux[i] = Mux1();
-    distanceMinMux[i].c[0] <== bodies[i][4] * 2; // maxBits: 15 = numBits(2 * 13 * scalingFactor) (maxNum: 26_000)
+    distanceMinMux[i].c[0] <== bodies[i][2] * 2; // maxBits: 15 = numBits(2 * 13 * scalingFactor) (maxNum: 26_000)
     distanceMinMux[i].c[1] <== 0;
     distanceMinMux[i].s <== isZero[i].out;
 
@@ -45,19 +45,15 @@ template DetectCollision(totalBodies) {
     lessThan[i].in[1] <== distanceMinMux[i].out; // maxBits: 15 (maxNum: 26_000)
 
     mux[i] = Mux1();
-    mux[i].c[0] <== bodies[i][4]; // maxBits: 14 = numBits(13 * scalingFactor) (maxNum: 13_000)
+    mux[i].c[0] <== bodies[i][2]; // maxBits: 14 = numBits(13 * scalingFactor) (maxNum: 13_000)
     mux[i].c[1] <== 0;
     mux[i].s <== lessThan[i].out;
     out_bodies[i][0] <== bodies[i][0];
     out_bodies[i][1] <== bodies[i][1];
-    out_bodies[i][2] <== bodies[i][2];
-    out_bodies[i][3] <== bodies[i][3];
-    out_bodies[i][4] <== mux[i].out;
+    out_bodies[i][2] <== mux[i].out;
     // log("out_bodies[i][0]", out_bodies[i][0]);
     // log("out_bodies[i][1]", out_bodies[i][1]);
     // log("out_bodies[i][2]", out_bodies[i][2]);
-    // log("out_bodies[i][3]", out_bodies[i][3]);
-    // log("out_bodies[i][4]", out_bodies[i][4]);
 
     mux2[i] = Mux1();
     mux2[i].c[0] <== tmp_missiles[i][2];
@@ -71,7 +67,5 @@ template DetectCollision(totalBodies) {
 
   out_missile[0] <== tmp_missiles[totalBodies - 1][0]; // last iteration's x
   out_missile[1] <== tmp_missiles[totalBodies - 1][1]; // last iteration's y
-  out_missile[2] <== missile[2]; // original x velocity
-  out_missile[3] <== missile[3]; // original y velocity
-  out_missile[4] <== tmp_missiles[totalBodies - 1][2]; // last iteration's radius
+  out_missile[2] <== tmp_missiles[totalBodies - 1][2]; // last iteration's radius
 }

--- a/circuits/stepState.circom
+++ b/circuits/stepState.circom
@@ -15,39 +15,48 @@ template StepState(totalBodies, steps) {
   component forceAccumulator[steps];
   component calculateMissile[steps];
   component detectCollision[steps];
-  signal tmp_bodies[steps + 1][totalBodies][5];
-  tmp_bodies[0] <== bodies;
   
-
-  signal tmp_missile[steps + 1][5];
-  tmp_missile[0] <== missiles[0];
+  var tmp_body[totalBodies][5] = bodies;
+  var tmp_missile[5] = missiles[0];
 
   component mux[steps];
   component isZero[steps];
 
   for (var i = 0; i < steps; i++) {
     forceAccumulator[i] = ForceAccumulator(totalBodies);
-    forceAccumulator[i].bodies <== tmp_bodies[i];
-
+    forceAccumulator[i].bodies <== tmp_body;
     // TODO: check whether constraints can be reduced by only calculating position since 
     // velocity is constant
     calculateMissile[i] = CalculateMissile();
-    calculateMissile[i].in_missile <== tmp_missile[i];
+    calculateMissile[i].in_missile <== tmp_missile;
 
     // TODO: Ask WEI whether it's possible to skip this calculation if the radius is 0, 
     // meaning there is no missile (or at least reduce the constraints needed?)
     detectCollision[i] = DetectCollision(totalBodies);
-    detectCollision[i].bodies <== forceAccumulator[i].out_bodies;
-    detectCollision[i].missile <== calculateMissile[i].out_missile;
+    detectCollision[i].missile[0] <== calculateMissile[i].out_missile[0]; // x
+    detectCollision[i].missile[1] <== calculateMissile[i].out_missile[1]; // y
+    detectCollision[i].missile[2] <== calculateMissile[i].out_missile[4]; // radius
+    for  (var j = 0; j < totalBodies; j++) {
+      detectCollision[i].bodies[j][0] <== forceAccumulator[i].out_bodies[j][0]; // x
+      detectCollision[i].bodies[j][1] <== forceAccumulator[i].out_bodies[j][1]; // y
+      detectCollision[i].bodies[j][2] <== forceAccumulator[i].out_bodies[j][4]; // radius
+    }
 
     // Some bodies may have lost radius due to collision, so we need to update the bodies
     // TODO: check whether it's possible to reduce constraint by removing velocity here
-    tmp_bodies[i + 1] <== detectCollision[i].out_bodies;
+    // tmp_bodies[i + 1] <== detectCollision[i].out_bodies;
+    for (var j = 0; j < totalBodies; j++) {
+      tmp_body[j][0] = detectCollision[i].out_bodies[j][0];
+      tmp_body[j][1] = detectCollision[i].out_bodies[j][1];
+      tmp_body[j][2] = forceAccumulator[i].out_bodies[j][2];
+      tmp_body[j][3] = forceAccumulator[i].out_bodies[j][3];
+      tmp_body[j][4] = detectCollision[i].out_bodies[j][2];
+    }
 
     // NOTE: Check whether the missile radius is now 0 meaning that it has collided with a
     // body
     isZero[i] = IsZero();
-    isZero[i].in <== detectCollision[i].out_missile[4];
+    isZero[i].in <== detectCollision[i].out_missile[2];
 
     // NOTE: If the missile has collided with a body or gone off screen, then the next 
     // missile should come from the missiles input instead of the current missile.
@@ -57,15 +66,29 @@ template StepState(totalBodies, steps) {
     // game as well.
     // TODO: check whether it's possible to reduce constraints by removing velocity here
     mux[i] = MultiMux1(5);
-    for (var j = 0; j < 5; j++) {
-      mux[i].c[j][0] <== detectCollision[i].out_missile[j];
-      mux[i].c[j][1] <== missiles[i + 1][j];
-    }
+
+    mux[i].c[0][0] <== detectCollision[i].out_missile[0];
+    mux[i].c[0][1] <== missiles[i + 1][0];
+
+    mux[i].c[1][0] <== detectCollision[i].out_missile[1];
+    mux[i].c[1][1] <== missiles[i + 1][1];
+
+    mux[i].c[2][0] <== missiles[i][2];
+    mux[i].c[2][1] <== missiles[i + 1][2];
+
+    mux[i].c[3][0] <== missiles[i][3];
+    mux[i].c[3][1] <== missiles[i + 1][3];
+
+    mux[i].c[4][0] <== detectCollision[i].out_missile[2];
+    mux[i].c[4][1] <== missiles[i + 1][4];
     mux[i].s <== isZero[i].out;
 
-    for (var j = 0; j < 5; j++) {
-      tmp_missile[i + 1][j] <== mux[i].out[j];
-    }
+    tmp_missile[0] = mux[i].out[0];
+    tmp_missile[1] = mux[i].out[1];
+    tmp_missile[2] = mux[i].out[2];
+    tmp_missile[3] = mux[i].out[3];
+    tmp_missile[4] = mux[i].out[4];
+
   }
-  out_bodies <== tmp_bodies[steps];
+  out_bodies <== tmp_body;
 }

--- a/docs/index.js
+++ b/docs/index.js
@@ -11,8 +11,8 @@ const rightEdge = windowWidth, topEdge = 0, leftEdge = 0, bottomEdge = windowWid
 
 const boundaryRadius = windowWidth / 2
 let n = 0, img1
-const fps = 300
-const preRun = 10000
+const fps = 30
+const preRun = 0
 const prime = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
 const admin = false
 const minRadius = 50
@@ -180,7 +180,9 @@ function forceAccumulatorBigInts(bodies) {
 }
 
 function runComputationBigInt(bodies, missiles) {
+  // console.dir({ 'bodies': bodies }, { depth: null })
   bodies = forceAccumulatorBigInts(bodies)
+  // console.dir({ 'bodies': bodies }, { depth: null })
   return detectCollisionBigInt(bodies, missiles)
   // bodies = results.bodies
   // missiles = results.missiles

--- a/test/detectCollisionMain.test.js
+++ b/test/detectCollisionMain.test.js
@@ -11,12 +11,18 @@ describe("detectCollisionMain circuit", () => {
 
   const sampleInput = {
     "bodies": [
-      ["226000", "42000", "9999", "3710", "100000"],
-      ["363000", "658000", "6680", "13740", "75000"],
-      ["679000", "500000", "12290", "12520", "50000"]
+      ["226000", "42000", "100000"],
+      ["363000", "658000", "75000"],
+      ["679000", "500000", "50000"]
     ],
-    "missile": ["226000", "42000", "10000", "10000", "100000"]
+    "missile": ["226000", "42000", "100000"]
   };
+  const jsSampleInput = JSON.parse(JSON.stringify(sampleInput))
+  jsSampleInput.bodies[0].splice(2, 0, "9999", "3710")
+  jsSampleInput.bodies[1].splice(2, 0, "6680", "13740")
+  jsSampleInput.bodies[2].splice(2, 0, "12290", "12520")
+  jsSampleInput.missile.splice(2, 0, "10000", "10000")
+
   const sanityCheck = true;
 
   before(async () => {
@@ -44,14 +50,16 @@ describe("detectCollisionMain circuit", () => {
   it("has the correct output", async () => {
     const bodiesBefore = []
     for (let i = 0; i < sampleInput.bodies.length; i++) {
-      bodiesBefore.push(convertScaledStringArrayToBody(sampleInput.bodies[i]))
+      bodiesBefore.push(convertScaledStringArrayToBody(jsSampleInput.bodies[i]))
     }
-    const missiles = [convertScaledStringArrayToBody(sampleInput.missile)]
-    // console.log({ bodiesBefore, missiles })
+    const missiles = [convertScaledStringArrayToBody(jsSampleInput.missile)]
+    // console.dir({ bodiesBefore, missiles }, { depth: null })
     const results = detectCollisionBigInt(bodiesBefore, missiles)
     // console.log({ results })
-    const out_bodies = results.bodies.map(convertScaledBigIntBodyToArray)
-    const out_missile = results.missiles.map(convertScaledBigIntBodyToArray)[0]
+    let out_bodies = results.bodies.map(convertScaledBigIntBodyToArray)
+    out_bodies.forEach(b => b.splice(2, 2))
+    let out_missile = results.missiles.map(convertScaledBigIntBodyToArray)[0]
+    out_missile.splice(2, 2)
     // console.log({ out_bodies })
     // console.log({ out_missile })
     const expected = { out_bodies, out_missile };

--- a/test/stepStateMain.test.js
+++ b/test/stepStateMain.test.js
@@ -19,7 +19,7 @@ describe("stepStateMain circuit", () => {
       ["679000", "500000", "12290", "12520", "50000"]
     ],
 
-    // NOTE: need to have array of 11 when step = 10 because missiles need to be n + 1
+    // NOTE: need to have array of 2 when step = 1 because missiles need to be n + 1
     missiles: [
       ["226000", "42000", "10000", "10000", "100000"],
       ["0", "0", "0", "0", "0"],
@@ -40,9 +40,11 @@ describe("stepStateMain circuit", () => {
     circuit = await hre.circuitTest.setup("stepStateMain");
   });
 
+  const steps = 10
+
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInput, sanityCheck);
-    console.log(`| stepState(3, 10) | ${witness.length} |`)
+    console.log(`| stepState(3, ${steps}) | ${witness.length} |`)
     await circuit.checkConstraints(witness);
   });
 
@@ -51,7 +53,7 @@ describe("stepStateMain circuit", () => {
       sampleInput,
       sanityCheck
     );
-    // console.log({ witness })
+    console.dir({ witness: witness._labels }, { depth: null })
 
     // assert.propertyVal(witness, "main.squared", sampleInput.squared);
     // assert.propertyVal(witness, "main.calculatedRoot", sampleInput.calculatedRoot);
@@ -64,13 +66,13 @@ describe("stepStateMain circuit", () => {
     let missiles = sampleInput.missiles.map(convertScaledStringArrayToBody)
     // console.dir({ bodies }, { depth: null })
     // console.dir({ missiles }, { depth: null })
-    for (let i = 0; i < 10; i++) {
+
+    for (let i = 0; i < steps; i++) {
       const results = runComputationBigInt(bodies, missiles)
       bodies = results.bodies
       missiles = results.missiles
     }
     const out_bodies = bodies.map(convertScaledBigIntBodyToArray)
-    // console.log({ out_bodies })
     const expected = { out_bodies };
     const witness = await circuit.calculateWitness(sampleInput, sanityCheck);
     await circuit.assertOut(witness, expected);

--- a/test/stepStateMain.test.js
+++ b/test/stepStateMain.test.js
@@ -53,7 +53,7 @@ describe("stepStateMain circuit", () => {
       sampleInput,
       sanityCheck
     );
-    console.dir({ witness: witness._labels }, { depth: null })
+    // console.dir({ witness: witness._labels }, { depth: null })
 
     // assert.propertyVal(witness, "main.squared", sampleInput.squared);
     // assert.propertyVal(witness, "main.calculatedRoot", sampleInput.calculatedRoot);


### PR DESCRIPTION
reduced `detectCollision` and `stepState` by checking bit lengths, ignoring velocity in `detectCollision` and using `var` instead of `signal` in `stepState`.