### PR TITLE
updated square root but only in calculateForce

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,18 +170,18 @@ You should see something like:
 
 Currently the project is targeting [powersOfTau28_hez_final_20.ptau](https://github.com/iden3/snarkjs/blob/master/README.md#7-prepare-phase-2) which has a limit of 1MM constraints. Below is a table of the number of constraints used by each circuit.
 
-| Circuit | Non-Linear Constraints |
-|---------|-------------|
-| absoluteValueSubtraction(252) | 259 |
-| acceptableMarginOfError(60) | 128 |
-| calculateForce() | 717 |
-| detectCollision(3) | 510 |
-| forceAccumulator(3) | 2821 |
-| getDistance(20) | 142 |
-| limiter(252) | 257 |
-| lowerLimiter(252) | 257 |
-| nft(3, 10) | 28039 |
-| stepState(3, 10) | 33531 |
+| Circuit | Non-Linear Constraints | seconds at 25fps under 1MM constraints |
+|---------|-------------|---------------------------------------------------|
+| absoluteValueSubtraction(252) | 257 | 155.64 |
+| acceptableMarginOfError(60) | 125 | 320 |
+| calculateForce() | 279 | 143.37 |
+| detectCollision(3) | 348 | 114.94 |
+| forceAccumulator(3) | 1522 | 26.28 |
+| getDistance(20) | 88 | 454.55 |
+| limiter(252) | 254 | 157.48|
+| lowerLimiter(252) | 254 | 157.48|
+| nft(3, 10) | 15184 | 26.34 |
+| stepState(3, 10) | 19121 | 20.92 |
 
 # built using circom-starter
 

--- a/circuits/approxMath.circom
+++ b/circuits/approxMath.circom
@@ -4,7 +4,7 @@ include "../node_modules/circomlib/circuits/comparators.circom";
 
 function approxSqrt(n) {
     if (n == 0) {
-        return 0;
+        return [0,0,0];
     }
 
     var lo = 0;
@@ -16,7 +16,7 @@ function approxSqrt(n) {
         // TODO: Make more accurate by checking if lo + hi is odd or even before bit shifting
         midSquared = (mid * mid);
         if (midSquared == n) {
-            return mid; // Exact square root found
+            return [lo,mid,hi]; // Exact square root found
         } else if (midSquared < n) {
             lo = mid + 1; // Adjust lower bound
         } else {
@@ -25,7 +25,7 @@ function approxSqrt(n) {
     }
     // If we reach here, no exact square root was found.
     // return the closest approximation
-    return mid;
+    return [lo, mid, hi];
 }
 
 function approxDiv(dividend, divisor) {
@@ -55,6 +55,26 @@ function approxDiv(dividend, divisor) {
   // Output the midpoint as our approximated quotient after iterations
   return midPoint;
 }
+
+
+// template AbsoulteValueSubtraction(maxDiffMaxBits) {
+//   signal input in[2];
+//   signal input maxDiff;
+//   signal output out;
+
+//   signal diffA = in[0] - in[1];
+//   signal diffAOffset = diffA + maxDiff;
+
+//   signal diffB = in[1] - in[0];
+//   signal diffBOffset <== diffB + maxDiff;
+
+//   diffAOffset - diffBOffset - in[0]
+
+//   signal isZero = IsZero();
+
+
+
+// }
 
 
 template AcceptableMarginOfError (n) {

--- a/circuits/calculateMissile.circom
+++ b/circuits/calculateMissile.circom
@@ -51,21 +51,21 @@ template CalculateMissile() {
   // position X is only going to increase from 0 to windowWidthScaled
   // it needs to be kept less than windowWidthScaled
   // can return 0 if it exceeds and use this information to remove the missile
-  component positionLimiterX = Limiter(20);
-  positionLimiterX.in <== new_pos[0] + maxVectorScaled; // maxBits: 20 (maxNum: 1_020_000)
-  positionLimiterX.limit <== windowWidthScaled + maxVectorScaled; // maxBits: 20 (maxNum: 1_010_000)
-  positionLimiterX.rather <== 0;
+  component calcMissilePositionLimiterX = Limiter(20);
+  calcMissilePositionLimiterX.in <== new_pos[0] + maxVectorScaled; // maxBits: 20 (maxNum: 1_020_000)
+  calcMissilePositionLimiterX.limit <== windowWidthScaled + maxVectorScaled; // maxBits: 20 (maxNum: 1_010_000)
+  calcMissilePositionLimiterX.rather <== 0;
 
   // This is for the radius of the missile
   // If it went off screen in the x direction the radius should go to 0
   // if not then we want to use the real radius until it's checked
   // on the y dimension
-  component isZeroX = IsZero();
-  isZeroX.in <== positionLimiterX.out;
+  component calcMissileIsZeroX = IsZero();
+  calcMissileIsZeroX.in <== calcMissilePositionLimiterX.out;
   component muxX = Mux1();
   muxX.c[0] <== in_missile[4];
   muxX.c[1] <== 0;
-  muxX.s <== isZeroX.out;
+  muxX.s <== calcMissileIsZeroX.out;
 
   // Since the plane goes from 0 to windowWidthScaled on the y axis from top to bottom
   // the missile will approach 0 after starting at windowWidthScaled

--- a/circuits/getDistance.circom
+++ b/circuits/getDistance.circom
@@ -1,12 +1,18 @@
 pragma circom 2.1.6;
 
 include "approxMath.circom";
+include "helpers.circom";
 
 template GetDistance(n) {
   signal input x1; // maxBits: 20 (maxNum: 1_000_000) = windowWidthScaled
   signal input y1; // maxBits: 20 (maxNum: 1_000_000) = windowWidthScaled
   signal input x2; // maxBits: 20 (maxNum: 1_000_000) = windowWidthScaled
   signal input y2; // maxBits: 20 (maxNum: 1_000_000) = windowWidthScaled
+  var scalingFactorFactor = 3;
+  var scalingFactor = 10 ** scalingFactorFactor;
+  var windowWidth = 1000;
+  var windowWidthScaled = windowWidth * scalingFactor;
+  var positionMax = windowWidthScaled;
   signal output distance;
 
   // signal dx <== x2 - x1;
@@ -22,15 +28,21 @@ template GetDistance(n) {
   signal dyAbs <== absoluteValueSubtraction2.out; // maxBits: 20 (maxNum: 1_000_000) = windowWidthScaled
 
   signal dxs <== dxAbs * dxAbs; // maxBits: 40 = 20 * 2 (maxNum: 1_000_000_000_000)
+  var dxsMax = positionMax ** 2;
   signal dys <== dyAbs * dyAbs; // maxBits: 40 = 20 * 2 (maxNum: 1_000_000_000_000)
   signal distanceSquared <== dxs + dys; // maxBits: 41 = 40 + 1 (maxNum: 2_000_000_000_000)
+  var distanceSquaredMax = dxsMax + dxsMax;
 
-  // NOTE: confirm this is correct
-  distance <-- approxSqrt(distanceSquared); // maxBits: 21 (maxNum: 1_414_214) ~= 41 / 2 + 2
-  component acceptableMarginOfError = AcceptableMarginOfError((2 * n) + 1);
-  acceptableMarginOfError.expected <== distance ** 2; // maxBits: 41 (maxNum: 2_000_001_237_796) ~= 21 * 2
-  acceptableMarginOfError.actual <== distanceSquared; // maxBits: 41
-  // margin of error should be midpoint between squares
-  acceptableMarginOfError.marginOfError <== distance * 2; // maxBits: 22 (maxNum: 2_828_428)
-  acceptableMarginOfError.out === 1;
+  component sqrt = Sqrt(distanceSquaredMax);
+  sqrt.squaredValue <== distanceSquared;
+  distance <== sqrt.root;
+
+  // // NOTE: confirm this is correct
+  // distance <-- approxSqrt(distanceSquared); // maxBits: 21 (maxNum: 1_414_214) ~= 41 / 2 + 2
+  // component acceptableMarginOfError = AcceptableMarginOfError((2 * n) + 1);
+  // acceptableMarginOfError.expected <== distance ** 2; // maxBits: 41 (maxNum: 2_000_001_237_796) ~= 21 * 2
+  // acceptableMarginOfError.actual <== distanceSquared; // maxBits: 41
+  // // margin of error should be midpoint between squares
+  // acceptableMarginOfError.marginOfError <== distance * 2; // maxBits: 22 (maxNum: 2_828_428)
+  // acceptableMarginOfError.out === 1;
 }

--- a/circuits/helpers.circom
+++ b/circuits/helpers.circom
@@ -15,3 +15,21 @@ function getVy(body) {
 function getMass(body) {
   return body[4];
 }
+
+function maxBits(n) {
+  var i = 0;
+   while(n > 0) {
+    i++;
+    n = n >> 1;
+   }
+   return i;
+}
+function getBiggest(options, len) {
+  var biggest = 0;
+  for (var i = 0; i < len; i++) {
+    if (options[i] > biggest) {
+      biggest = options[i];
+    }
+  }
+  return biggest;
+}

--- a/circuits/stepState.circom
+++ b/circuits/stepState.circom
@@ -23,6 +23,12 @@ template StepState(totalBodies, steps) {
   component isZero[steps];
 
   for (var i = 0; i < steps; i++) {
+    // log("tmp_body[0][0]", tmp_body[0][0]);
+    // log("tmp_body[0][1]", tmp_body[0][1]);
+    // log("tmp_body[0][2]", tmp_body[0][2]);
+    // log("tmp_body[0][3]", tmp_body[0][3]);
+    // log("tmp_body[0][4]", tmp_body[0][4]);
+
     forceAccumulator[i] = ForceAccumulator(totalBodies);
     forceAccumulator[i].bodies <== tmp_body;
     // TODO: check whether constraints can be reduced by only calculating position since 

--- a/circuits/stepStateMain.circom
+++ b/circuits/stepStateMain.circom
@@ -2,4 +2,4 @@ pragma circom 2.1.6;
 
 include "stepState.circom";
 
-component main { public [ bodies, missiles ]} = StepState(3, 10);
+component main { public [ bodies, missiles ]} = StepState(3, 1);

--- a/circuits/stepStateMain.circom
+++ b/circuits/stepStateMain.circom
@@ -2,4 +2,4 @@ pragma circom 2.1.6;
 
 include "stepState.circom";
 
-component main { public [ bodies, missiles ]} = StepState(3, 1);
+component main { public [ bodies, missiles ]} = StepState(3, 10);

--- a/docs/index.js
+++ b/docs/index.js
@@ -433,12 +433,14 @@ function sqrtApprox(n) {
   var lo = 0n;
   var hi = n >> 1n;
   var mid, midSquared;
-
+  // console.log({ lo, hi })
   while (lo <= hi) {
     mid = (lo + hi) >> 1n; // multiplication by multiplicative inverse is not what we want so we use >>
+    // console.log({ lo, mid, hi })
     // TODO: Make more accurate by checking if lo + hi is odd or even before bit shifting
     midSquared = (mid * mid);
     if (midSquared == n) {
+      console.log(`final perfect`, { lo, mid, hi })
       return mid; // Exact square root found
     } else if (midSquared < n) {
       lo = mid + 1n; // Adjust lower bound
@@ -448,6 +450,7 @@ function sqrtApprox(n) {
   }
   // If we reach here, no exact square root was found.
   // return the closest approximation
+  console.log(`final approx`, { lo, mid, hi })
   return mid;
 }
 

--- a/docs/index.js
+++ b/docs/index.js
@@ -242,7 +242,7 @@ function approxDist(x1, y1, x2, y2) {
   const dxs = absX * absX
   const dys = absY * absY
   const distanceSquared = dxs + dys
-  const distance = sqrtApprox(distanceSquared)
+  const distance = approxSqrt(distanceSquared)
   return distance
 }
 
@@ -359,7 +359,7 @@ function calculateForceBigInt(body1, body2) {
   } else {
     distanceSquared = unboundDistanceSquared
   }
-  let distance = sqrtApprox(distanceSquared)
+  let distance = approxSqrt(distanceSquared)
   // console.log({ distance })
   // console.log({ distanceSquared })
 
@@ -390,42 +390,38 @@ function calculateForceBigInt(body1, body2) {
   return [forceX, forceY]
 }
 
+
 function approxDiv(dividend, divisor) {
   if (dividend == 0n) {
     return 0n
   }
-  var bitsDivident = 0n;
-  var dividendCopy = dividend;
-  while (dividendCopy > 0n) {
-    bitsDivident++;
-    dividendCopy = dividendCopy >> 1n;
-  }
 
   // Create internal signals for our binary search
-  var lowerBound, upperBound, midPoint, testProduct;
+  var lo, hi, mid, testProduct;
 
   // Initialize our search space
-  lowerBound = 0n;
-  upperBound = dividend;  // Assuming worst case where divisor = 1
+  lo = 0n;
+  hi = dividend;  // Assuming worst case where divisor = 1
 
-  for (var i = 0; i < bitsDivident; i++) {  // 32 iterations for 32-bit numbers as an example
-    midPoint = (upperBound + lowerBound) >> 1n;
-    testProduct = midPoint * divisor;
+  while (lo < hi) {  // 32 iterations for 32-bit numbers as an example
+    mid = (hi + lo + 1n) >> 1n;
+    testProduct = mid * divisor;
 
     // Adjust our bounds based on the test product
     if (testProduct > dividend) {
-      upperBound = midPoint;
+      hi = mid - 1n;
     } else {
-      lowerBound = midPoint;
+      lo = mid;
     }
   }
-
-  // Output the midpoint as our approximated quotient after iterations
-  // quotient <== midPoint;
-  return midPoint;
+  // console.log({ lo, mid, hi })
+  // Output the lo as our approximated quotient after iterations
+  // quotient <== lo;
+  return lo;
 }
 
-function sqrtApprox(n) {
+
+function approxSqrt(n) {
   // console.log({ n })
   if (n == 0n) {
     return 0n;
@@ -440,7 +436,7 @@ function sqrtApprox(n) {
     // TODO: Make more accurate by checking if lo + hi is odd or even before bit shifting
     midSquared = (mid * mid);
     if (midSquared == n) {
-      console.log(`final perfect`, { lo, mid, hi })
+      // console.log(`final perfect`, { lo, mid, hi })
       return mid; // Exact square root found
     } else if (midSquared < n) {
       lo = mid + 1n; // Adjust lower bound
@@ -450,7 +446,7 @@ function sqrtApprox(n) {
   }
   // If we reach here, no exact square root was found.
   // return the closest approximation
-  console.log(`final approx`, { lo, mid, hi })
+  // console.log(`final approx`, { lo, mid, hi })
   return mid;
 }
 
@@ -845,14 +841,22 @@ function convertScaledBigIntToFloat(value) {
 }
 
 
+function calculateTime(constraints, steps = 1) {
+  const totalSteps = steps * 1_000_000 / constraints
+  const fps = 25
+  const sec = totalSteps / fps
+  return Math.round(sec * 100) / 100
+}
+
 if (module) {
   module.exports = {
     convertScaledStringArrayToBody,
     convertScaledStringArrayToFloat,
     convertScaledBigIntBodyToArray,
     calculateForce,
-    sqrtApprox,
+    approxSqrt,
     approxDiv,
+    calculateTime,
     vectorLimit,
     scalingFactor,
     runComputation,

--- a/test/absoluteValueSubtraction.test.js
+++ b/test/absoluteValueSubtraction.test.js
@@ -1,5 +1,6 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
+const { calculateTime } = require("../docs/index.js");
 
 describe("absoluteValueSubtraction circuit", () => {
   let circuit;
@@ -22,7 +23,10 @@ describe("absoluteValueSubtraction circuit", () => {
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInput[0].in, sanityCheck);
-    console.log(`| absoluteValueSubtraction(252) | ${witness.length} |`)
+    const inputs = sampleInput[0].in.in.length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep)
+    console.log(`| absoluteValueSubtraction(252) | ${perStep} | ${secRounded} |`)
     await circuit.checkConstraints(witness);
   });
 
@@ -31,6 +35,8 @@ describe("absoluteValueSubtraction circuit", () => {
       sampleInput[0].in,
       sanityCheck
     );
+    // console.log({ witness })
+
     // assert.propertyVal(witness, "main.x1", sampleInput.x1);
     // assert.propertyVal(witness, "main.x2", sampleInput.x2);
     // assert.propertyVal(witness, "main.x3", sampleInput.x3);

--- a/test/acceptableMarginOfError.test.js
+++ b/test/acceptableMarginOfError.test.js
@@ -1,5 +1,6 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
+const { calculateTime } = require("../docs/index.js");
 
 describe("acceptableMarginOfError circuit", () => {
   let circuit;
@@ -18,7 +19,11 @@ describe("acceptableMarginOfError circuit", () => {
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInput, sanityCheck);
-    console.log(`| acceptableMarginOfError(60) | ${witness.length} |`)
+    // get the number of inputs
+    const inputs = Object.keys(sampleInput).length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep)
+    console.log(`| acceptableMarginOfError(60) | ${perStep} | ${secRounded} |`)
     await circuit.checkConstraints(witness);
   });
 

--- a/test/calculateForceMain.test.js
+++ b/test/calculateForceMain.test.js
@@ -1,6 +1,12 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
-const { calculateForceBigInt, convertFloatToScaledBigInt, vectorLimit, convertBigIntToModP, convertScaledStringArrayToBody } = require("../docs/index.js");
+const {
+  calculateTime,
+  calculateForceBigInt,
+  convertBigIntToModP,
+  convertScaledStringArrayToBody
+} = require("../docs/index.js");
+
 const p = 21888242871839275222246405745257275088548364400416034343698204186575808495617n;
 
 describe("calculateForceMain circuit", () => {
@@ -41,7 +47,11 @@ describe("calculateForceMain circuit", () => {
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInputs[0], sanityCheck);
-    console.log(`| calculateForce() | ${witness.length} |`)
+    // get the number of inputs
+    const inputs = sampleInputs[0].in_bodies.length * sampleInputs[0].in_bodies[0].length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep)
+    console.log(`| calculateForce() | ${perStep} | ${secRounded} |`)
     await circuit.checkConstraints(witness);
   });
 

--- a/test/detectCollisionMain.test.js
+++ b/test/detectCollisionMain.test.js
@@ -1,6 +1,7 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
 const {
+  calculateTime,
   detectCollisionBigInt,
   convertScaledStringArrayToBody,
   convertScaledBigIntBodyToArray
@@ -31,7 +32,10 @@ describe("detectCollisionMain circuit", () => {
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInput, sanityCheck);
-    console.log(`| detectCollision(3) | ${witness.length} |`)
+    const inputs = sampleInput.bodies.length * sampleInput.bodies[0].length + sampleInput.missile.length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep)
+    console.log(`| detectCollision(3) | ${perStep} | ${secRounded} |`)
     await circuit.checkConstraints(witness);
   });
 

--- a/test/forceAccumulator.test.js
+++ b/test/forceAccumulator.test.js
@@ -3,9 +3,7 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
 const {
-  calculateForce,
-  sqrtApprox,
-  scalingFactor,
+  calculateTime,
   convertScaledStringArrayToBody,
   convertScaledBigIntBodyToArray,
   forceAccumulatorBigInts
@@ -30,7 +28,10 @@ describe("forceAccumulatorMain circuit", () => {
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInput, sanityCheck);
-    console.log(`| forceAccumulator(3) | ${witness.length} |`)
+    const inputs = sampleInput.bodies.length * sampleInput.bodies[0].length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep)
+    console.log(`| forceAccumulator(3) | ${perStep} | ${secRounded} |`)
     await circuit.checkConstraints(witness);
   });
 

--- a/test/getDistanceMain.test.js
+++ b/test/getDistanceMain.test.js
@@ -1,5 +1,6 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
+const { calculateTime } = require("../docs/index.js");
 
 describe("getDistanceMain circuit", () => {
   let circuit;
@@ -18,7 +19,10 @@ describe("getDistanceMain circuit", () => {
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInput, sanityCheck);
-    console.log(`| getDistance(20) | ${witness.length} |`)
+    const inputs = Object.keys(sampleInput).length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep)
+    console.log(`| getDistance(20) | ${perStep} | ${secRounded} |`)
     await circuit.checkConstraints(witness);
   });
 

--- a/test/limiterMain.test.js
+++ b/test/limiterMain.test.js
@@ -1,5 +1,6 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
+const { calculateTime } = require("../docs/index.js");
 
 describe("limiterMain circuit", () => {
   let circuit;
@@ -38,7 +39,10 @@ describe("limiterMain circuit", () => {
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInputs[0].sampleInput, sanityCheck);
-    console.log(`| limiter(252) | ${witness.length} |`)
+    const inputs = Object.keys(sampleInputs[0].sampleInput).length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep)
+    console.log(`| limiter(252) | ${perStep} | ${secRounded}|`)
     await circuit.checkConstraints(witness);
   });
 

--- a/test/lowerLimiterMain.test.js
+++ b/test/lowerLimiterMain.test.js
@@ -1,6 +1,7 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
 
+const { calculateTime } = require("../docs/index.js");
 describe("lowerLimiterMain circuit", () => {
   let circuit;
 
@@ -38,7 +39,10 @@ describe("lowerLimiterMain circuit", () => {
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInputs[0].sampleInput, sanityCheck);
-    console.log(`| lowerLimiter(252) | ${witness.length} |`)
+    const inputs = Object.keys(sampleInputs[0].sampleInput).length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep)
+    console.log(`| lowerLimiter(252) | ${perStep} | ${secRounded}|`)
     await circuit.checkConstraints(witness);
   });
 

--- a/test/nft.test.js
+++ b/test/nft.test.js
@@ -3,9 +3,7 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
 const {
-  calculateForce,
-  sqrtApprox,
-  scalingFactor,
+  calculateTime,
   convertScaledStringArrayToBody,
   convertScaledBigIntBodyToArray,
   forceAccumulatorBigInts
@@ -23,7 +21,7 @@ describe("nft circuit", () => {
     ]
   };
   const sanityCheck = true;
-
+  const steps = 10;
   before(async () => {
     circuit = await hre.circuitTest.setup("nft");
 
@@ -31,7 +29,10 @@ describe("nft circuit", () => {
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInput, sanityCheck);
-    console.log(`| nft(3, 10) | ${witness.length} |`)
+    const inputs = sampleInput.bodies.length * sampleInput.bodies[0].length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep, steps)
+    console.log(`| nft(3, 10) | ${perStep} | ${secRounded} |`)
     await circuit.checkConstraints(witness);
   });
 
@@ -51,7 +52,7 @@ describe("nft circuit", () => {
   it("has the correct output", async () => {
     let bodies = sampleInput.bodies.map(convertScaledStringArrayToBody)
     // console.dir({ bodies }, { depth: null })
-    for (let i = 0; i < 10; i++) {
+    for (let i = 0; i < steps; i++) {
       bodies = forceAccumulatorBigInts(bodies)
     }
     const out_bodies = bodies.map(convertScaledBigIntBodyToArray)

--- a/test/stepStateMain.test.js
+++ b/test/stepStateMain.test.js
@@ -3,6 +3,7 @@
 const hre = require("hardhat");
 const { assert } = require("chai");
 const {
+  calculateTime,
   runComputationBigInt,
   convertScaledStringArrayToBody,
   convertScaledBigIntBodyToArray,
@@ -23,6 +24,15 @@ describe("stepStateMain circuit", () => {
     missiles: [
       ["226000", "42000", "10000", "10000", "100000"],
       ["0", "0", "0", "0", "0"],
+      ["0", "0", "0", "0", "0"],
+      ["0", "0", "0", "0", "0"],
+      ["0", "0", "0", "0", "0"],
+      ["0", "0", "0", "0", "0"],
+      ["0", "0", "0", "0", "0"],
+      ["0", "0", "0", "0", "0"],
+      ["0", "0", "0", "0", "0"],
+      ["0", "0", "0", "0", "0"],
+      ["0", "0", "0", "0", "0"],
     ]
   };
   const sanityCheck = true;
@@ -31,11 +41,14 @@ describe("stepStateMain circuit", () => {
     circuit = await hre.circuitTest.setup("stepStateMain");
   });
 
-  const steps = 1
+  const steps = sampleInput.missiles.length - 1
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInput, sanityCheck);
-    console.log(`| stepState(3, ${steps}) | ${witness.length} |`)
+    const inputs = sampleInput.bodies.length * sampleInput.bodies[0].length + sampleInput.missiles.length * sampleInput.missiles[0].length
+    const perStep = witness.length - inputs
+    const secRounded = calculateTime(perStep, steps)
+    console.log(`| stepState(3, ${steps}) | ${perStep} | ${secRounded} |`)
     await circuit.checkConstraints(witness);
   });
 
@@ -44,7 +57,7 @@ describe("stepStateMain circuit", () => {
       sampleInput,
       sanityCheck
     );
-    console.dir({ witness: witness._labels }, { depth: null })
+    // console.dir({ witness: witness._labels }, { depth: null })
 
     // assert.propertyVal(witness, "main.squared", sampleInput.squared);
     // assert.propertyVal(witness, "main.calculatedRoot", sampleInput.calculatedRoot);
@@ -59,6 +72,7 @@ describe("stepStateMain circuit", () => {
     // console.dir({ missiles }, { depth: null })
 
     for (let i = 0; i < steps; i++) {
+      // console.dir({ 'bodies[0]': bodies[0] }, { depth: null })
       const results = runComputationBigInt(bodies, missiles)
       bodies = results.bodies
       missiles = results.missiles

--- a/test/stepStateMain.test.js
+++ b/test/stepStateMain.test.js
@@ -23,15 +23,6 @@ describe("stepStateMain circuit", () => {
     missiles: [
       ["226000", "42000", "10000", "10000", "100000"],
       ["0", "0", "0", "0", "0"],
-      ["0", "0", "0", "0", "0"],
-      ["0", "0", "0", "0", "0"],
-      ["0", "0", "0", "0", "0"],
-      ["0", "0", "0", "0", "0"],
-      ["0", "0", "0", "0", "0"],
-      ["0", "0", "0", "0", "0"],
-      ["0", "0", "0", "0", "0"],
-      ["0", "0", "0", "0", "0"],
-      ["0", "0", "0", "0", "0"]
     ]
   };
   const sanityCheck = true;
@@ -40,7 +31,7 @@ describe("stepStateMain circuit", () => {
     circuit = await hre.circuitTest.setup("stepStateMain");
   });
 
-  const steps = 10
+  const steps = 1
 
   it("produces a witness with valid constraints", async () => {
     const witness = await circuit.calculateWitness(sampleInput, sanityCheck);
@@ -53,7 +44,7 @@ describe("stepStateMain circuit", () => {
       sampleInput,
       sanityCheck
     );
-    // console.dir({ witness: witness._labels }, { depth: null })
+    console.dir({ witness: witness._labels }, { depth: null })
 
     // assert.propertyVal(witness, "main.squared", sampleInput.squared);
     // assert.propertyVal(witness, "main.calculatedRoot", sampleInput.calculatedRoot);


### PR DESCRIPTION
I noticed that the calculation of `approxSqrt` had correlated properties between `lo`, `mid` and `hi` and whether the approximate square root would be larger or smaller than the actual square root. This makes it possible to skip the `absoluteValueSubtraction` comparator as well as reduce the remaining comparator bitsize by half.

I'm going to try doing the same thing for `approxDiv`