### PR TITLE
fix the mem-leak

### DIFF
--- a/src/anybody.js
+++ b/src/anybody.js
@@ -1083,12 +1083,13 @@ export class Anybody extends EventEmitter {
 
   async drawBodies(attachToCanvas = true) {
     // if (!this.bodiesGraphic) {
-    this.bodiesGraphic = this.p.createGraphics(this.windowWidth, this.windowHeight)
+
+    this.bodiesGraphic ||= this.p.createGraphics(this.windowWidth, this.windowHeight)
     this.bodiesGraphic.noStroke()
 
     // this.bodiesGraphic.blendMode(this.p.DIFFERENCE)
     // }
-    // this.bodiesGraphic.clear()
+    this.bodiesGraphic.clear()
     // if (this.mode == 'nft') this.drawBorder()
     // this.bodiesGraphic.strokeWeight(1)
     const bodyCopies = []


### PR DESCRIPTION
The context from createGraphics must be released or reused. I switched to reusing.

## Before

js heap grows linearly as the animation runs (1.5mb/s, i've seen it hit 2GB so far haha)
<img width="652" alt="Screenshot 2024-03-06 at 2 59 45 PM" src="https://github.com/okwme/anybody-problem/assets/282016/c0c3bb9b-2b49-41a2-977e-1a4313d01aae">

chills out when paused
<img width="652" alt="Screenshot 2024-03-06 at 3 00 45 PM" src="https://github.com/okwme/anybody-problem/assets/282016/320fbec7-1049-41ea-9599-5a86d7b3dc0a">

## After

Nice and steady alloc/release graph :)

<img width="1095" alt="Screenshot 2024-03-07 at 10 04 33 AM" src="https://github.com/okwme/anybody-problem/assets/282016/13bc52dc-a7dd-49a5-a673-2567ed9e7345">
