### PR TITLE
passing solver happy path test

### DIFF
--- a/circuits/game_8_100.circom
+++ b/circuits/game_8_100.circom
@@ -1,5 +1,0 @@
-pragma circom 2.1.6;
-
-include "stepState.circom";
-
-component main { public [ bodies ]} = StepState(8, 100);

--- a/circuits/game_8_50.circom
+++ b/circuits/game_8_50.circom
@@ -1,0 +1,5 @@
+pragma circom 2.1.6;
+
+include "stepState.circom";
+
+component main { public [ bodies ]} = StepState(8, 50);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "circom:nft-test": "yarn circom nft_3_20 && yarn circom nft_4_20 && yarn circom nft_5_20 && yarn circom nft_6_20 && yarn circom nft_7_20 && yarn circom nft_8_20 && yarn circom nft_9_20 && yarn circom nft_10_20",
     "circom:nft-prod": "yarn circom nft_3_500 && yarn circom nft_4_100 && yarn circom nft_5_100 && yarn circom nft_6_100 && yarn circom nft_7_100 && yarn circom nft_8_100 && yarn circom nft_9_50 && yarn circom nft_10_50",
     "circom:game-test": "yarn circom game_3_20 && yarn circom game_4_20 && yarn circom game_5_20 && yarn circom game_6_20 && yarn circom game_7_20 && yarn circom game_8_20 && yarn circom game_9_20 && yarn circom game_10_20",
-    "circom:game-prod": "yarn circom game_3_500 && yarn circom game_4_100 && yarn circom game_5_100 && yarn circom game_6_100 && yarn circom game_7_100 && yarn circom game_8_100 && yarn circom game_9_50 && yarn circom game_10_50",
+    "circom:game-prod": "yarn circom game_3_500 && yarn circom game_4_100 && yarn circom game_5_100 && yarn circom game_6_100 && yarn circom game_7_100 && yarn circom game_8_50 && yarn circom game_9_50 && yarn circom game_10_50",
     "test:circom": "ls test/*.js | grep -v -e 'bodies' -e 'problems' -e 'solver' -e 'metadata' | xargs npx hardhat test",
     "test:solidity": "hardhat test test/problems.test.js test/metadata.test.js test/bodies.test.js test/solver.test.js",
     "test": "hardhat test",

--- a/src/anybody.js
+++ b/src/anybody.js
@@ -4,7 +4,6 @@ import EventEmitter from 'events'
 import Sound from './sound.js'
 import { Visuals } from './visuals.js'
 import { _validateSeed, Calculations } from './calculations.js'
-import { stepLife, stepWithering } from './life.js'
 
 export class Anybody extends EventEmitter {
   constructor(p, options = {}) {
@@ -233,12 +232,6 @@ export class Anybody extends EventEmitter {
   }
 
   step() {
-    const { live, withering } = stepLife(this.bodies, this.witheringBodies)
-    this.witheringBodies ||= []
-    this.witheringBodies.push(...withering)
-    this.witheringBodies = stepWithering(this.witheringBodies)
-    this.bodies = live
-
     this.bodies = this.forceAccumulator(this.bodies)
     var results = this.detectCollision(this.bodies, this.missiles)
     this.bodies = results.bodies
@@ -302,6 +295,7 @@ export class Anybody extends EventEmitter {
   }
 
   finish() {
+    let results = {}
     // this.finished = true
     // this.setPause(true)
     this.calculateBodyFinal()
@@ -330,11 +324,12 @@ export class Anybody extends EventEmitter {
         }
         missileInits.push([0, 0, 0, 0, 0])
       }
-      this.emit('finished', {
+      results = {
         missiles: JSON.parse(JSON.stringify(missileInits)),
         bodyInits: JSON.parse(JSON.stringify(this.bodyInits)),
         bodyFinal: JSON.parse(JSON.stringify(this.bodyFinal))
-      })
+      }
+      this.emit('finished', results)
     }
     this.bodyInits = JSON.parse(JSON.stringify(this.bodyFinal))
     this.alreadyRun = this.frames
@@ -344,6 +339,7 @@ export class Anybody extends EventEmitter {
     })
     this.bodyFinal = []
     // this.setPause(false)
+    return results
   }
 
   generateBodies() {
@@ -385,7 +381,8 @@ export class Anybody extends EventEmitter {
           position: this.createVector(px, py),
           velocity: this.createVector(vx, vy),
           radius: radius,
-          life: b.life.toNumber(),
+          starLvl: b.starLvl.toNumber(),
+          maxStarLvl: b.maxStarLvl.toNumber(),
           mintedBodyIndex: b.mintedBodyIndex.toNumber(),
           c: this.colorArrayToTxt(this.randomColor(0, 200, bodyRNG))
         }

--- a/src/calculations.js
+++ b/src/calculations.js
@@ -295,7 +295,8 @@ export const Calculations = {
       newBody.velocity.y =
         body.vy || this.convertFloatToScaledBigInt(body.velocity.y)
       newBody.radius = this.convertFloatToScaledBigInt(body.radius)
-      newBody.life = body.life
+      newBody.starLvl = body.starLvl
+      newBody.maxStarLvl = body.maxStarLvl
       newBody.mintedBodyIndex = body.mintedBodyIndex
       newBody.c = body.c
       newBody.bodyIndex = body.bodyIndex

--- a/src/life.js
+++ b/src/life.js
@@ -1,24 +1,4 @@
-export const MAX_LIFE = 60 * 50 // 60 sec at 50 fps
 export const WITHERING_STEPS = 200
-
-export function stepLife(bodies) {
-  const live = []
-  const withering = []
-  for (const body of bodies) {
-    if (typeof body.life !== 'number') {
-      body.life = MAX_LIFE
-    } else {
-      body.life -= 1
-    }
-
-    live.push(body)
-    if (body.life < 0 && body.life > -WITHERING_STEPS) {
-      withering.push(body)
-    }
-  }
-
-  return { live, withering }
-}
 
 export function stepWithering(witheringBodies) {
   const withering = []

--- a/test/problems.test.js
+++ b/test/problems.test.js
@@ -4,7 +4,7 @@ const ethers = hre.ethers
 // const { describe, it } = require('mocha')
 
 import {
-  proverTickIndex,
+  getTicksRun,
   deployContracts,
   correctPrice,
   /*splitterAddress,*/ getParsedEventLogs,
@@ -27,7 +27,7 @@ describe('Problem Tests', function () {
         const bodyCount = name.split('_')[1]
         storedAddress = await problems.verifiers(
           bodyCount,
-          proverTickIndex[bodyCount]
+          getTicksRun(bodyCount)
         )
       } else {
         const functionName = name.toLowerCase()
@@ -404,7 +404,7 @@ describe('Problem Tests', function () {
     for (const [name, contract] of Object.entries(deployedContracts)) {
       if (name.indexOf('Verifier') === -1) continue
       const bodyCount = name.split('_')[1]
-      const tickCount = proverTickIndex[bodyCount]
+      const tickCount = await getTicksRun(bodyCount)
       const storedAddress = await problems.verifiers(bodyCount, tickCount)
       const actualAddress = contract.address
       expect(storedAddress).to.equal(actualAddress)


### PR DESCRIPTION
- Replaced `life` with `starLvl` and `maxStarLvl` to track how many times a body has been included in a successful match
- Converted utils to use game version instead of nft version for everything
- Made tests use only 20 step proofs instead of live durations for speed (should make #64 possible)
- Had to reduce 8 body circuit to 50 steps due to complexity
- Added one happy path test in solver suite, need to add more and fully restore the ones I reduced
- Realized there is a vulnerability in how the prover is currently designed, outlined in #72 
- Also realized much lower risk exploit for slightly improving your score, outlined in #73
- Tried new numbers for cost of new bodies and rewards, looks like you can buy up to the 8th body when you maximize the bodies in play as soon as possible. Didn't confirm but since there's a bonus for beating it in half tile it should enable a super player to get all 10 bodies with purchase of a single problem.