### PR TITLE
fixed win logic bug

### DIFF
--- a/src/anybody.js
+++ b/src/anybody.js
@@ -41,7 +41,7 @@ export class Anybody extends EventEmitter {
       timer: 60 * FPS, // 60 seconds * 50 frames per second
       aimHelper: false,
       target: 'outside', // 'outside' or 'inside'
-      showLives: true, // true or false
+      showLives: true // true or false
     }
 
     // Merge the default options with the provided options
@@ -303,6 +303,7 @@ export class Anybody extends EventEmitter {
   }
 
   finish() {
+    if (this.finalBatchSent) return
     let results = {}
     // this.finished = true
     // this.setPause(true)
@@ -351,7 +352,7 @@ export class Anybody extends EventEmitter {
       this.mode == 'game' &&
       this.bodies.reduce((a, c) => a + c.radius, 0) == 0
     ) {
-      alert('You won!')
+      this.finalBatchSent = true
     }
     return results
   }

--- a/src/visuals.js
+++ b/src/visuals.js
@@ -23,8 +23,6 @@ export const Visuals = {
       this.setPause(true)
       return
     }
-    const enoughBodies =
-      -this.bodies.filter((b) => !b.life || b.life > 0).length >= 3
 
     this.frames++
     const results = this.step(this.bodies, this.missiles)
@@ -60,6 +58,13 @@ export const Visuals = {
     const framesIsAtStopEveryInterval =
       (this.frames - this.alreadyRun) % this.stopEvery == 0
     const didNotJustPause = !this.justPaused
+    // console.log({
+    //   stopEvery: this.stopEvery,
+    //   alreadyRun: this.alreadyRun,
+    //   frames: this.frames,
+    //   framesIsAtStopEveryInterval,
+    //   frames_lt_timer: this.frames < this.timer
+    // })
     if (
       isNotFirstFrame &&
       notPaused &&
@@ -67,13 +72,10 @@ export const Visuals = {
       didNotJustPause &&
       this.frames < this.timer
     ) {
-      if (didNotJustPause && enoughBodies && !this.won) {
+      if (didNotJustPause) {
         this.finish()
-        if (this.bodies.reduce((a, c) => a + c.radius, 0) == 0) {
-          this.won = true
-        }
       }
-      // if (this.optimistic && enoughBodies) {
+      // if (this.optimistic) {
       //   this.started()
       // }
     } else {
@@ -84,17 +86,13 @@ export const Visuals = {
       this.gameOver = true
     }
     if (
-      this.stopEvery == 0 &&
+      !this.won &&
       this.mode == 'game' &&
-      this.bodies.reduce((a, c) => a + c.radius, 0) == 0 &&
-      !this.won
+      this.bodies.reduce((a, c) => a + c.radius, 0) == 0
     ) {
+      this.witherAllBodies()
+      this.gameOver = true
       this.won = true
-      alert('You won!')
-    }
-    if (this.frames == this.timer && !this.won) {
-      // this.setPause(true)
-      alert('Time is up!')
     }
   },
   drawPause() {
@@ -405,7 +403,11 @@ export const Visuals = {
       p.textSize(100)
       // game over in the center of screen
       p.textAlign(p.CENTER)
-      p.text('GAME OVER', this.windowWidth / 2, this.windowHeight / 2 - 60)
+      p.text(
+        this.won ? 'SUCCESS' : 'GAME OVER',
+        this.windowWidth / 2,
+        this.windowHeight / 2 - 60
+      )
       p.pop()
       return
     }
@@ -495,7 +497,6 @@ export const Visuals = {
     for (let i = 0; i < this.explosions.length; i++) {
       const _explosion = this.explosions[i]
       const bomb = _explosion[0]
-      console.log(i / this.explosions.length)
       this.p.fill('red')
       this.p.ellipse(bomb.x, bomb.y, bomb.i * 2, bomb.i * 2)
       _explosion.shift()


### PR DESCRIPTION
Noticed that proofs weren't being generated anymore and it's cause holdover using `enoughBodies` so I got rid of it and moved around `this.won` until it showed up correctly while not preventing final proof from being generated. Also added "SUCCESS" for win screen but should probably do something more involved with #84 .

Noticed that #76 seems to have slightly unexpected behaviour. What I'm seeing is that at the moment the game ends the bodies turn into withering blobs at the point where the game ends. This is correct for game over but as #84 is approached we should ensure that the bodies "final" position is actually when the proof is generated and not when the game is actually won. At the circuit and contract level the point that matters is when the proof is generated, so in the code this is when `this.finalBatchSent` is set to `true` (currently line 355 of anybody.js). Once that's set we should stop updating the positions.... Maybe this should also only happen to the bodies that are in fact turning into stars? As in the ones where `starLvl == maxStarLvl`.

I'll reference this info in #84 for @psugihara 