### PR TITLE
shared game over hook

### DIFF
--- a/src/anybody.js
+++ b/src/anybody.js
@@ -240,6 +240,7 @@ export class Anybody extends EventEmitter {
     this.sound?.playGameOver()
     this.gameOver = true
     this.won = won
+    this.emit('gameOver', {won})
   }
 
   setPause(newPauseState = !this.paused) {

--- a/src/anybody.js
+++ b/src/anybody.js
@@ -235,6 +235,13 @@ export class Anybody extends EventEmitter {
     }
   }
 
+  handleGameOver = ({ won }) => {
+    this.witherAllBodies()
+    this.sound?.playGameOver()
+    this.gameOver = true
+    this.won = won
+  }
+
   setPause(newPauseState = !this.paused) {
     if (typeof newPauseState !== 'boolean') {
       newPauseState = !this.paused

--- a/src/visuals.js
+++ b/src/visuals.js
@@ -276,19 +276,14 @@ export const Visuals = {
       this.justPaused = false
     }
     if (this.frames - this.startingFrame + FPS >= this.timer) {
-      this.witherAllBodies()
-      this.gameOver = true
-      this.sound?.playGameOver()
+      this.handleGameOver({ won: false })
     }
     if (
       !this.won &&
       this.mode == 'game' &&
       this.bodies.reduce((a, c) => a + c.radius, 0) == 0
     ) {
-      this.witherAllBodies()
-      this.sound?.playGameOver()
-      this.gameOver = true
-      this.won = true
+      this.handleGameOver({ won: true })
     }
     this.firstFrame = false
   },


### PR DESCRIPTION
> this is nice. in #94 I was getting frustrated trying to make it look smooth at the end when a body turns into a star and it made me realize we should probably just have a dedicated game over sequence where we do all of it rather than try to integrate it smoothly into game play. This function could be where it's expanded for more happening than just music.

https://github.com/okwme/anybody-problem/pull/96#discussion_r1556402808

firing off async functions from here will be good for gameover sequencing